### PR TITLE
Fix avdwnl: add missing WindowsAHQDB match arm

### DIFF
--- a/avdwnl/src/main.rs
+++ b/avdwnl/src/main.rs
@@ -28,7 +28,8 @@ macro_rules! dwnl {
           InstallerFormat::WindowsInstallerExe => ".exe",
           InstallerFormat::WindowsInstallerMsi => ".msi",
           InstallerFormat::WindowsUWPMsix => ".msix",
-          InstallerFormat::WindowsZip => ".zip"
+          InstallerFormat::WindowsZip => ".zip",
+          InstallerFormat::WindowsAHQDB => ".ahqdb"
         };
 
         let fle = format!("{}{ext}", $cntr);

--- a/avdwnl/src/main.rs
+++ b/avdwnl/src/main.rs
@@ -29,7 +29,7 @@ macro_rules! dwnl {
           InstallerFormat::WindowsInstallerMsi => ".msi",
           InstallerFormat::WindowsUWPMsix => ".msix",
           InstallerFormat::WindowsZip => ".zip",
-          InstallerFormat::WindowsAHQDB => ".ahqdb"
+          InstallerFormat::WindowsAHQDB => ".ahqdb",
         };
 
         let fle = format!("{}{ext}", $cntr);


### PR DESCRIPTION
## Summary
- The `dwnl!` macro in `avdwnl/src/main.rs` has a non-exhaustive match on `InstallerFormat`
- `ahqstore-types 3.17.2` added `WindowsAHQDB` variant, but the match was never updated
- This causes a **compilation error** that blocks ALL `/store set` submissions on issue #29

## Error (from CI logs of run #22041527400)
```
error[E0004]: non-exhaustive patterns: `InstallerFormat::WindowsAHQDB` not covered
 --> avdwnl/src/main.rs:26:13
```

## Fix
Adds the missing `InstallerFormat::WindowsAHQDB => ".ahqdb"` match arm.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added support for an additional Windows installer format, improving installer compatibility and edge-case handling.
  * Maintained existing ZIP installer behavior and formatting consistency to avoid regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->